### PR TITLE
prevent multiple vlaues for 'cls'

### DIFF
--- a/main/json_fix/__init__.py
+++ b/main/json_fix/__init__.py
@@ -90,6 +90,6 @@ if not hasattr(JSONEncoder, "original_default"):
     JSONEncoder.encode = PatchedJsonEncoder.encode # needs to be overridden because of https://stackoverflow.com/questions/16405969/how-to-change-json-encoding-behaviour-for-serializable-python-object/16406798#16406798
     
     original_dump = json.dump
-    json.dump = lambda obj, *args, **kwargs: original_dump((object_to_jsonable(obj) if isinstance(obj, builtin_jsonable) else obj), *args, cls=PatchedJsonEncoder, **kwargs)
+    json.dump = lambda obj, *args, **kwargs: original_dump((object_to_jsonable(obj) if isinstance(obj, builtin_jsonable) else obj), *args, **dict({'cls':PatchedJsonEncoder}, **kwargs))
 
 def fix_it(): pass # to support the old interface 


### PR DESCRIPTION
With a 'cls' declaration separate from kwargs, it's possible to have multiple values for 'cls'. This leads to TypeError: json.dump() got multiple values for keyword argument 'cls'.